### PR TITLE
Security hardening: lock down Actions + gate Fly deploy on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["**"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   node:
     name: Node (${{ matrix.app }})

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -6,14 +6,18 @@ on:
     branches: ["main"]
     types: [completed]
 
+permissions:
+  contents: read
+
 concurrency:
   group: fly-deploy-chowsr
   cancel-in-progress: true
 
 jobs:
   deploy-chowsr:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'imtmcdonald' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    environment: production
     defaults:
       run:
         working-directory: chowsr

--- a/chowsr/README.md
+++ b/chowsr/README.md
@@ -73,9 +73,8 @@ fly deploy
 
 #### GitHub deploys
 
-On merges to `main`, GitHub Actions can deploy to Fly if you add a repository secret named `FLY_API_TOKEN`.
+On merges to `main`, GitHub Actions can deploy to Fly if you add a secret named `FLY_API_TOKEN` (recommended: add it as an environment secret for an environment named `production`).
 
 ## Notes
 
 - Don't commit `.env` (it often contains secrets).
-


### PR DESCRIPTION
deploy on CI

## Summary

This PR tightens GitHub Actions security and makes deploys safer by ensuring Fly deployments only run after the CI workflow succeeds on main, using a protected environment.

## Changes

  - Adds least-privilege permissions to workflows:
      - CI now uses contents: read (.github/workflows/ci.yml:1)
      - Fly deploy workflow uses contents: read and runs only
        for repo owner imtmcdonald (.github/workflows/deploy-
        fly.yml:1)
  - Updates Fly deploy workflow to:
      - Trigger on workflow_run (CI success) for main
      - Use environment: production (recommended for env-
        protected secrets)
  - Fixes gitleaks PR scanning by providing GITHUB_TOKEN and
    explicit permissions (.github/workflows/gitleaks.yml:1)
  - Updates docs to recommend storing FLY_API_TOKEN as an
    environment secret (chowsr/README.md:1)

 ###  How to enable deploys

  - Create GitHub Environment: production
  - Add environment secret: FLY_API_TOKEN
  - (Optional) Add required reviewers for production so only you
    can approve deploys

## Checklist

- [x] No secrets added (including sample configs)
- [x] App builds/runs locally for the changed path(s)
- [x] Docs updated (`README.md` and/or `docs/`)
- [x] AI-assisted changes reviewed and validated (see `docs/ai.md`)

